### PR TITLE
use QLVA as default policy

### DIFF
--- a/src/agent_factory.js
+++ b/src/agent_factory.js
@@ -1,17 +1,33 @@
 let Agent = require('./agent.js')
+let Q = require('./q.js')
+let Observable = require('./observable.js')
+let LinearValueApproximator = require('./linear_value_approximator.js')
+let utils = require('./utils.js')
 
 class AgentFactory {
+  static QLVAAgent(object, observables, actions) {
+    let approximator = new LinearValueApproximator({
+      statesSize: observables.reduce((acc, o) => acc + o.attributes.length, 0),
+      actionsSize: actions.length
+    })
 
-  build(object, observables, actions) {
+    let policy = new Q({ approximator: approximator, actions: actions })
 
-    let newAgentArgs = {
+    return this.create(object, observables, actions, policy)
+  }
+
+  static create(object, observables, actions, policy) {
+
+    return new Agent({
       object: object,
-      observables: observables,
-      policy: 'nothing for now', //refactor to allow passing in policy
+      observables: this._wrapObservables(observables),
+      policy: policy,
       actions: actions
-    }
+    })
+  }
 
-    return new Agent(newAgentArgs)
+  static _wrapObservables(observables) {
+    return observables.map((o) => Object.assign(o, Observable))
   }
 }
 

--- a/src/agent_list.js
+++ b/src/agent_list.js
@@ -5,13 +5,13 @@ class AgentList {
   // that implements all the public methods of
   // the type
   // and some custom methods like find, build
-  constructor(values = [], agentFactory = new AgentFactory()) {
+  constructor(values = [], agentFactory = AgentFactory) {
     this.values = values
     this.agentFactory = agentFactory
   }
 
-  build(object, observables, actions) {
-    let agent = this._buildAgent(object, observables, actions)
+  build(object, observables, actions, policyType = 'QLVAAgent') {
+    let agent = this._buildAgent(object, observables, actions, policyType)
     object.agent_id = this.values.length
     this.values.push(agent)
   }
@@ -36,10 +36,10 @@ class AgentList {
     return this.values[object.agent_id]
   }
 
-  _buildAgent(object, observables, actions) {
+  _buildAgent(object, observables, actions, policyType) {
     this._preventDuplicates(object)
 
-    return this.agentFactory.build(object, observables, actions)
+    return this.agentFactory[policyType](object, observables, actions)
   }
 
   _preventDuplicates(object) {

--- a/test/agent_factory_test.js
+++ b/test/agent_factory_test.js
@@ -1,0 +1,38 @@
+let AgentFactory = require('../src/agent_factory.js')
+let Q = require('../src/q.js')
+let LinearValueApproximator = require('../src/linear_value_approximator.js')
+let assert = require('assert')
+
+describe('AgentFactory', function() {
+  describe('#create', function() {
+    it('creates an agent with a policy and observables', function() {
+      let obj = { y: 10, move: () => true }
+      let observable = { y: 10, attributes: ['y'] }
+      let policyDouble = {}
+
+      let agent = AgentFactory.create(obj, [observable], ['move'], policyDouble)
+
+      assert.deepEqual(agent.state, [10])
+      assert.equal(agent.policy, policyDouble)
+      assert.deepEqual(agent.actions, ['move'])
+    })
+  })
+
+  describe('#QLVAAgent', function() {
+    it('creates an agent with a Q policy and LVA approximation', function() {
+      let obj = { y: 10, x: 5, move: () => true, attributes: ['x', 'y'] }
+      let observable = { y: 10, attributes: ['y'] }
+
+      let agent = AgentFactory.QLVAAgent(obj, [obj, observable], ['move'])
+      let policy = agent.policy
+      let approximator = policy.approximator
+
+      assert.ok(policy instanceof Q)
+      assert.deepEqual(policy.actions, ['move'])
+
+      assert.ok(approximator instanceof LinearValueApproximator)
+      assert.equal(approximator.statesSize, 3)
+      assert.equal(approximator.actionsSize, 1)
+    })
+  })
+})

--- a/test/environment_test.js
+++ b/test/environment_test.js
@@ -12,10 +12,7 @@ describe('Environment', function() {
       object.move = () => object.y += 5
 
       env.createSentience([object], [observable], ['move'])
-      let agent = env.agents[0]
-
-      assert.deepEqual(agent.observables, [observable])
-      assert.deepEqual(agent.actions, ['move'])
+      assert.ok(env.agents.length == 1)
     })
 
     it('does not create multiple agents for the same object', function () {


### PR DESCRIPTION
# What's Up
Struggling with a way to assign a newly created agent a policy under the hood, as well as to allow the possibility to pass in a default policy into the agent. 

# Solution
For now this is possible to an extent with the implementation of an AgentFactory. The only implemented agent type is the QLVAAgent, an Agent which uses Q learning and Linear Value Approximation (Yet to be fully implemented)